### PR TITLE
feat: Register and list admins

### DIFF
--- a/e2e/RegisterAdmins.spec.tsx
+++ b/e2e/RegisterAdmins.spec.tsx
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  // Login as an admin
+  await page.goto("/login");
+  await page.getByLabel("Email").fill("development.admin@gmail.com");
+  await page.getByLabel("Password").fill("changeme123*/");
+  await page.getByRole("button", { name: "Submit" }).click();
+
+  // Assert the admins page is loaded
+  expect(page.waitForURL(/\/admins$/)).toBeTruthy();
+});
+
+test("The fields are validated", async ({ page }) => {
+  // Go to the register page
+  await page.getByRole("link", { name: "Register admin" }).click();
+  expect(page.waitForURL(/\/register\/admins$/)).toBeTruthy();
+
+  // Fill the form
+  await page.getByLabel("Full name").fill("a");
+  await page.getByLabel("Email").fill("a");
+  await page.getByLabel("Password").fill("insecure");
+  await page.getByRole("button", { name: "Submit" }).click();
+
+  // Assert the errors are shown
+  await expect(
+    page.getByText("Full name must be at least 4 characters long")
+  ).toBeVisible();
+  await expect(page.getByText("Invalid email")).toBeVisible();
+  await expect(
+    page.getByText(
+      "Must contain at least one letter, one number and one special character"
+    )
+  ).toBeVisible();
+});
+
+test.describe.serial("Admin registration", () => {
+  test("Admins can register new admins", async ({ page }) => {
+    // Go to the register page
+    await page.getByRole("link", { name: "Register admin" }).click();
+    expect(page.waitForURL(/\/register\/admins$/)).toBeTruthy();
+
+    // Fill the form
+    await page.getByLabel("Full name").fill("Inés Alvarez");
+    await page.getByLabel("Email").fill("ines.alvarez.fake@gmail.com");
+    await page.getByLabel("Password").fill("upbbga2020*/");
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    // Assert the alert is shown
+    await expect(
+      page.getByText("The admin has been registered!")
+    ).toBeVisible();
+
+    // Assert the admin is shown in the table
+    expect(page.waitForURL(/\/admins$/)).toBeTruthy();
+    await expect(page.getByText("Inés Alvarez")).toBeVisible();
+  });
+
+  test("Admins can't register new admins with an existing email", async ({
+    page
+  }) => {
+    // Go to the register page
+    await page.getByRole("link", { name: "Register admin" }).click();
+    expect(page.waitForURL(/\/register\/admins$/)).toBeTruthy();
+
+    // Fill the form
+    const email = "ines.alvarez.fake@gmail.com";
+    await page.getByLabel("Full name").fill("Inés Alvarez");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill("upbbga2020*/");
+    await page.getByRole("button", { name: "Submit" }).click();
+
+    // Assert the alert is shown
+    await expect(
+      page.getByText(`Email ${email} is already in use`)
+    ).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "dayjs": "1.11.10",
     "lucide-react": "^0.274.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
+  dayjs:
+    specifier: 1.11.10
+    version: 1.11.10
   lucide-react:
     specifier: ^0.274.0
     version: 0.274.0(react@18.2.0)
@@ -1173,6 +1176,10 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
+  /dayjs@1.11.10:
+    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
+    dev: false
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}

--- a/src/components/Navbar/NavigationOptions.ts
+++ b/src/components/Navbar/NavigationOptions.ts
@@ -11,10 +11,6 @@ export const NavigationOptions = {
   ],
   admin: [
     {
-      name: "Courses",
-      path: "/courses"
-    },
-    {
       name: "Admins",
       path: "/admins"
     },

--- a/src/components/session/AuthMiddleware.tsx
+++ b/src/components/session/AuthMiddleware.tsx
@@ -1,0 +1,50 @@
+import { AuthContext } from "@/context/AuthContext";
+import { SessionRole } from "@/hooks/useSession";
+import { Loader2 } from "lucide-react";
+import { useContext } from "react";
+import { Navigate } from "react-router-dom";
+import { toast } from "sonner";
+
+interface AuthMiddlewareProps {
+  children: React.ReactNode;
+  mustBeLoggedIn?: boolean;
+  roles?: SessionRole[];
+}
+
+export const AuthMiddleware = ({
+  roles,
+  mustBeLoggedIn,
+  children
+}: AuthMiddlewareProps) => {
+  const { isLoading, isLoggedIn, user } = useContext(AuthContext);
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        <Loader2 className="animate-spin mx-auto" />
+      </div>
+    );
+  }
+
+  if (mustBeLoggedIn) {
+    // Prevent access to logged-out users
+    if (!isLoggedIn || !user) {
+      toast.error("You must be logged in to access this page");
+      return <Navigate to="/login" />;
+    }
+
+    // Prevent access to users without the required role (if needed)
+    if (roles && !roles.includes(user.role)) {
+      toast.error("You don't have permission to access this page");
+      return <Navigate to="/" />;
+    }
+  } else {
+    // Prevent access to logged-in users
+    if (isLoggedIn && user) {
+      toast("You are already logged in");
+      return <Navigate to="/" />;
+    }
+  }
+
+  return children;
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,113 @@
+import { cn } from "@/lib/utils";
+import * as React from "react";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("bg-primary font-medium text-primary-foreground", className)}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption
+};

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { whoamiService } from "@/services/session/session.services";
+import { useEffect, useState } from "react";
 
 export type SessionUser = {
   uuid: string;
@@ -9,8 +10,22 @@ export type SessionUser = {
 export const useSession = () => {
   const [user, setUser] = useState<SessionUser | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-
   const isLoggedIn = !isLoading && !!user;
+
+  useEffect(() => {
+    recoverSession();
+  }, []);
+
+  const recoverSession = async () => {
+    setIsLoading(true);
+
+    const { success, user } = await whoamiService();
+    if (success && user) {
+      setUser(user);
+    }
+
+    setIsLoading(false);
+  };
 
   const login = (user: SessionUser) => {
     setIsLoading(true);

--- a/src/hooks/useSession.tsx
+++ b/src/hooks/useSession.tsx
@@ -1,9 +1,11 @@
 import { whoamiService } from "@/services/session/session.services";
 import { useEffect, useState } from "react";
 
+export type SessionRole = "admin" | "student" | "teacher";
+
 export type SessionUser = {
   uuid: string;
-  role: "admin" | "student" | "teacher";
+  role: SessionRole;
   full_name: string;
 };
 
@@ -20,9 +22,7 @@ export const useSession = () => {
     setIsLoading(true);
 
     const { success, user } = await whoamiService();
-    if (success && user) {
-      setUser(user);
-    }
+    if (success && user) setUser(user);
 
     setIsLoading(false);
   };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,17 +1,18 @@
 import { Navbar } from "@/components/Navbar/Navbar.tsx";
+import { AuthMiddleware } from "@/components/session/AuthMiddleware";
+import { AuthContextProvider } from "@/context/AuthContext";
 import { Home } from "@/screens/Home";
+import { AdminsView } from "@/screens/admins-view/AdminsView";
 import { CoursesHome } from "@/screens/courses-home/CoursesHome";
 import { Login } from "@/screens/login/Login";
+import { RegisterAdmin } from "@/screens/register-admin/RegisterAdmin";
 import { RegisterStudent } from "@/screens/register-student/RegisterStudent";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
 
-import { AuthContextProvider } from "./context/AuthContext";
 import "./global.css";
-import { AdminsView } from "./screens/admins-view/AdminsView";
-import { RegisterAdmin } from "./screens/register-admin/RegisterAdmin";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -21,11 +22,39 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Navbar />
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/register/students" element={<RegisterStudent />} />
-          <Route path="/register/admins" element={<RegisterAdmin />} />
+          <Route
+            path="/login"
+            element={
+              <AuthMiddleware>
+                <Login />
+              </AuthMiddleware>
+            }
+          />
+          <Route
+            path="/register/students"
+            element={
+              <AuthMiddleware>
+                <RegisterStudent />
+              </AuthMiddleware>
+            }
+          />
+          <Route
+            path="/register/admins"
+            element={
+              <AuthMiddleware mustBeLoggedIn roles={["admin"]}>
+                <RegisterAdmin />
+              </AuthMiddleware>
+            }
+          />
           <Route path="/courses" element={<CoursesHome />} />
-          <Route path="/admins" element={<AdminsView />} />
+          <Route
+            path="/admins"
+            element={
+              <AuthMiddleware mustBeLoggedIn roles={["admin"]}>
+                <AdminsView />
+              </AuthMiddleware>
+            }
+          />
         </Routes>
       </BrowserRouter>
     </AuthContextProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,8 @@ import { Toaster } from "sonner";
 
 import { AuthContextProvider } from "./context/AuthContext";
 import "./global.css";
+import { AdminsView } from "./screens/admins-view/AdminsView";
+import { RegisterAdmin } from "./screens/register-admin/RegisterAdmin";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -21,7 +23,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register/students" element={<RegisterStudent />} />
+          <Route path="/register/admins" element={<RegisterAdmin />} />
           <Route path="/courses" element={<CoursesHome />} />
+          <Route path="/admins" element={<AdminsView />} />
         </Routes>
       </BrowserRouter>
     </AuthContextProvider>

--- a/src/screens/admins-view/AdminsView.tsx
+++ b/src/screens/admins-view/AdminsView.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table";
+import {
+  getRegisteredAdminsService,
+  registeredAdminDTO
+} from "@/services/accounts/accounts.services";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { PlusCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+dayjs.extend(relativeTime);
+
+export const AdminsView = () => {
+  const [admins, setAdmins] = useState<registeredAdminDTO[]>();
+  const navigate = useNavigate();
+
+  const getRegisteredAdmins = async () => {
+    const { success, admins, ...response } = await getRegisteredAdminsService();
+    if (success) {
+      setAdmins(admins);
+    } else {
+      toast.error(response.message);
+    }
+  };
+
+  useEffect(() => {
+    getRegisteredAdmins();
+  }, []);
+
+  return (
+    <main className="max-w-7xl mx-auto px-4">
+      <div className="flex flex-row items-center justify-between flex-wrap mb-2 gap-x-4">
+        <h1 className="font-bold text-3xl my-4">Current registered admins</h1>
+        <Button onClick={() => navigate("/register/admins")}>
+          <PlusCircle className="mr-3" />
+          Register admin
+        </Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Full Name</TableHead>
+            <TableHead>Creation Date</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {admins?.map((admin) => (
+            <TableRow key={`${admin.full_name}`.replace(" ", "").toLowerCase()}>
+              <TableCell>{admin.full_name}</TableCell>
+              <TableCell>{dayjs(admin.created_at).fromNow()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </main>
+  );
+};

--- a/src/screens/admins-view/AdminsView.tsx
+++ b/src/screens/admins-view/AdminsView.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -15,14 +15,13 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { PlusCircle } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { toast } from "sonner";
 
 dayjs.extend(relativeTime);
 
 export const AdminsView = () => {
   const [admins, setAdmins] = useState<registeredAdminDTO[]>();
-  const navigate = useNavigate();
 
   const getRegisteredAdmins = async () => {
     const { success, admins, ...response } = await getRegisteredAdminsService();
@@ -41,10 +40,13 @@ export const AdminsView = () => {
     <main className="max-w-7xl mx-auto px-4">
       <div className="flex flex-row items-center justify-between flex-wrap mb-2 gap-x-4">
         <h1 className="font-bold text-3xl my-4">Current registered admins</h1>
-        <Button onClick={() => navigate("/register/admins")}>
+        <Link
+          className={buttonVariants({ variant: "default" })}
+          to="/register/admins"
+        >
           <PlusCircle className="mr-3" />
           Register admin
-        </Button>
+        </Link>
       </div>
       <Table>
         <TableHeader>

--- a/src/screens/login/Form.tsx
+++ b/src/screens/login/Form.tsx
@@ -42,7 +42,9 @@ export const LoginForm = () => {
     if (response.success && response.user) {
       toast.success(response.message);
       setContextUser(response.user);
-      navigate("/courses");
+
+      if (response.user.role === "admin") navigate("/admins");
+      else navigate("/courses");
     } else {
       toast.error(response.message);
     }

--- a/src/screens/register-admin/Form.tsx
+++ b/src/screens/register-admin/Form.tsx
@@ -1,0 +1,142 @@
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { registerAdminService } from "@/services/accounts/accounts.services";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import * as z from "zod";
+
+const RegisterAdminSchema = z.object({
+  full_name: z
+    .string()
+    .min(4, "Full name must be at least 4 characters long")
+    .max(255, "Full name must be at most 255 characters long"),
+  email: z.string().email(),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters long")
+    .max(255, "Password must be at most 255 characters long")
+    .regex(
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?])[A-Za-z\d[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]{8,}$/,
+      "Must contain at least one letter, one number and one special character"
+    )
+});
+
+export const RegisterAdminForm = () => {
+  const [state, setState] = useState<"idle" | "loading">("idle");
+  const navigate = useNavigate();
+
+  const form = useForm<z.infer<typeof RegisterAdminSchema>>({
+    resolver: zodResolver(RegisterAdminSchema),
+    defaultValues: {
+      full_name: "",
+      email: "",
+      password: ""
+    }
+  });
+
+  const onSubmit = async (values: z.infer<typeof RegisterAdminSchema>) => {
+    setState("loading");
+
+    const { success, message } = await registerAdminService(values);
+    if (success) {
+      toast.success(message);
+      form.reset();
+      navigate("/admins");
+    } else {
+      toast.error(message);
+    }
+
+    setState("idle");
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="mx-auto my-4 max-w-md space-y-4 border p-4 shadow-sm"
+      >
+        <h1 className="text-center text-3xl font-semibold tracking-tight">
+          Register a new admin
+        </h1>
+        <FormField
+          control={form.control}
+          name="full_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Full name</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Enter admin's full name here..."
+                  {...field}
+                />
+              </FormControl>
+              {form.formState.errors.full_name && (
+                <FormMessage>
+                  {form.formState.errors.full_name.message}
+                </FormMessage>
+              )}
+            </FormItem>
+          )}
+        ></FormField>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Enter admin's email here..."
+                  required
+                  {...field}
+                />
+              </FormControl>
+              {form.formState.errors.email && (
+                <FormMessage>{form.formState.errors.email.message}</FormMessage>
+              )}
+            </FormItem>
+          )}
+        ></FormField>
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Enter initial admin's password here..."
+                  {...field}
+                />
+              </FormControl>
+              {form.formState.errors.password && (
+                <FormMessage>
+                  {form.formState.errors.password.message}
+                </FormMessage>
+              )}
+            </FormItem>
+          )}
+        ></FormField>
+        <Button
+          type="submit"
+          className="w-full"
+          isLoading={state === "loading"}
+        >
+          Submit
+        </Button>
+      </form>
+    </Form>
+  );
+};

--- a/src/screens/register-admin/RegisterAdmin.tsx
+++ b/src/screens/register-admin/RegisterAdmin.tsx
@@ -1,0 +1,9 @@
+import { RegisterAdminForm } from "./Form";
+
+export const RegisterAdmin = () => {
+  return (
+    <main className="px-4">
+      <RegisterAdminForm />
+    </main>
+  );
+};

--- a/src/screens/register-student/Form.tsx
+++ b/src/screens/register-student/Form.tsx
@@ -25,8 +25,8 @@ const RegisterStudentSchema = z.object({
   institutional_id: z.string().min(6).max(9).regex(/\d/, "Must be numeric"),
   password: z
     .string()
-    .min(8)
-    .max(255)
+    .min(8, "Password must be at least 8 characters long")
+    .max(255, "Password must be at most 255 characters long")
     .regex(
       /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?])[A-Za-z\d[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]{8,}$/,
       "Must contain at least one letter, one number and one special character"

--- a/src/services/accounts/accounts.services.ts
+++ b/src/services/accounts/accounts.services.ts
@@ -2,6 +2,7 @@ import { AxiosError } from "axios";
 
 import { GenericResponse, HttpRequester } from "../axios";
 
+// --- Register student ----
 type registerStudentDTO = {
   full_name: string;
   email: string;
@@ -28,3 +29,63 @@ export const registerStudentService = async (
     return { success: false, message: errorMessage };
   }
 };
+
+// --- Register admin ---
+type registerAdminDTO = {
+  full_name: string;
+  email: string;
+  password: string;
+};
+
+export const registerAdminService = async (
+  data: registerAdminDTO
+): Promise<GenericResponse> => {
+  const { axios } = HttpRequester.getInstance();
+
+  try {
+    await axios.post("/accounts/admins", data);
+    return { success: true, message: "The new admin account was created!" };
+  } catch (error) {
+    let errorMessage = "There was an error";
+
+    if (error instanceof AxiosError) {
+      const { message } = error.response?.data || "";
+      if (message) errorMessage = message;
+    }
+
+    return { success: false, message: errorMessage };
+  }
+};
+
+// --- Get registered admins ---
+export type registeredAdminDTO = {
+  full_name: string;
+  created_at: string;
+};
+
+type registeredAdminsResponse = GenericResponse & {
+  admins: registeredAdminDTO[];
+};
+
+export const getRegisteredAdminsService =
+  async (): Promise<registeredAdminsResponse> => {
+    const { axios } = HttpRequester.getInstance();
+
+    try {
+      const { data } = await axios.get("/accounts/admins");
+      return {
+        success: true,
+        message: "Admins were obtained successfully",
+        admins: data["admins"]
+      };
+    } catch (error) {
+      let errorMessage = "There was an error";
+
+      if (error instanceof AxiosError) {
+        const { message } = error.response?.data || "";
+        if (message) errorMessage = message;
+      }
+
+      return { success: false, message: errorMessage, admins: [] };
+    }
+  };

--- a/src/services/accounts/accounts.services.ts
+++ b/src/services/accounts/accounts.services.ts
@@ -44,7 +44,7 @@ export const registerAdminService = async (
 
   try {
     await axios.post("/accounts/admins", data);
-    return { success: true, message: "The new admin account was created!" };
+    return { success: true, message: "The admin has been registered!" };
   } catch (error) {
     let errorMessage = "There was an error";
 

--- a/src/services/session/session.services.ts
+++ b/src/services/session/session.services.ts
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 
 import { HttpRequester } from "../axios";
 
+// --- Login ---
 type loginDTO = {
   email: string;
   password: string;
@@ -22,6 +23,29 @@ export const loginService = async (data: loginDTO): Promise<LoginResponse> => {
     return {
       success: true,
       message: "You have been logged in!",
+      user: response.data.user
+    };
+  } catch (error) {
+    let errorMessage = "There was an error";
+
+    if (error instanceof AxiosError) {
+      const { message } = error.response?.data || "";
+      if (message) errorMessage = message;
+    }
+
+    return { success: false, message: errorMessage };
+  }
+};
+
+// --- Whoami ---
+export const whoamiService = async (): Promise<LoginResponse> => {
+  const { axios } = HttpRequester.getInstance();
+
+  try {
+    const response = await axios.get("/session/whoami");
+    return {
+      success: true,
+      message: "You are logged in!",
       user: response.data.user
     };
   } catch (error) {


### PR DESCRIPTION
## Includes 📋

- Table to list existing admins
- Form to register new admins
- Tests the admins form and table
- Middleware component to protect routes
- Recover session when the page is reloaded or reopened

## Related Issues 🔎

Closes #6, #21, #22 

<!-- ## Notes 📝 -->
<!-- Additional notes or implementation details. -->

## Screenshots 📸

| ![image](https://github.com/upb-code-labs/react-client/assets/62714297/8ee86b26-d0df-4036-a768-f5339466e2e1) | ![image](https://github.com/upb-code-labs/react-client/assets/62714297/97c48315-27da-4147-ba3a-4a84045d0938) |
| --- | --- |

| ![image](https://github.com/upb-code-labs/react-client/assets/62714297/7ad338b8-66f0-4507-8a33-3a7bc92a5ddf)| ![image](https://github.com/upb-code-labs/react-client/assets/62714297/4e5e3f04-4e23-4018-accd-ecf911e94a47) |
| --- | --- |

