### PR TITLE
fix: Show admin accounts creator

### DIFF
--- a/e2e/register/RegisterAdmins.spec.tsx
+++ b/e2e/register/RegisterAdmins.spec.tsx
@@ -43,7 +43,8 @@ test.describe.serial("Admin registration", () => {
     await page.waitForURL(/\/register\/admins$/);
 
     // Fill the form
-    await page.getByLabel("Full name").fill("Inés Alvarez");
+    const newAdminName = "Inés Alvarez";
+    await page.getByLabel("Full name").fill(newAdminName);
     await page.getByLabel("Email").fill("ines.alvarez.fake@gmail.com");
     await page.getByLabel("Password").fill("upbbga2020*/");
     await page.getByRole("button", { name: "Submit" }).click();
@@ -55,7 +56,23 @@ test.describe.serial("Admin registration", () => {
 
     // Assert the admin is shown in the table
     await page.waitForURL(/\/admins$/);
-    await expect(page.getByText("Inés Alvarez")).toBeVisible();
+
+    const newAdminRow = await page.getByRole("row", {
+      name: new RegExp(newAdminName)
+    });
+    await expect(newAdminRow).toBeVisible();
+
+    // Assert row cells
+    await expect(
+      newAdminRow.getByRole("cell", { name: newAdminName })
+    ).toBeVisible();
+    await expect(
+      newAdminRow.getByRole("cell", { name: "a few seconds ago" })
+    ).toBeVisible();
+    const creatorFullName = "Development Admin";
+    await expect(
+      newAdminRow.getByRole("cell", { name: creatorFullName })
+    ).toBeVisible();
   });
 
   test("Admins can't register new admins with an existing email", async ({

--- a/src/screens/admins-view/AdminsView.tsx
+++ b/src/screens/admins-view/AdminsView.tsx
@@ -53,13 +53,15 @@ export const AdminsView = () => {
           <TableRow>
             <TableHead>Full Name</TableHead>
             <TableHead>Creation Date</TableHead>
+            <TableHead>Created By</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {admins?.map((admin) => (
-            <TableRow key={`${admin.full_name}`.replace(" ", "").toLowerCase()}>
+            <TableRow key={admin.uuid}>
               <TableCell>{admin.full_name}</TableCell>
               <TableCell>{dayjs(admin.created_at).fromNow()}</TableCell>
+              <TableCell>{admin.created_by}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/services/accounts/get-registered-admins.service.ts
+++ b/src/services/accounts/get-registered-admins.service.ts
@@ -3,7 +3,9 @@ import { AxiosError } from "axios";
 import { GenericResponse, HttpRequester } from "../axios";
 
 export type registeredAdminDTO = {
+  uuid: string;
   full_name: string;
+  created_by: string;
   created_at: string;
 };
 


### PR DESCRIPTION
## Includes 📋

- Add a new column in the admins table to show who registered the admin.
- Use the admin UUID as the row key.
- Update tests to register admins.

## Related Issues 🔎

Closes #21 

<!-- ## Notes 📝 -->
<!-- Additional notes or implementation details. -->

<!-- ## Screenshots 📸 -->
<!-- Use the following table template to add mobile screenshots. -->
<!--
|     |     |
| --- | --- |
-->
