### PR TITLE
Feat/#275 download submission as student

### DIFF
--- a/e2e/grades/grades-workflow.spec.ts
+++ b/e2e/grades/grades-workflow.spec.ts
@@ -270,8 +270,6 @@ test.describe.serial("Grades workflow", () => {
     await expect(readyPhaseElm).toBeVisible();
     await expect(readyPhaseElm).toHaveAttribute("data-reached", "true");
 
-    // TODO: Assert the student can download the submitted file
-    /*
     const formTab = page.getByRole("tab", {
       name: "Test block 1 submission form",
       exact: true
@@ -288,7 +286,6 @@ test.describe.serial("Grades workflow", () => {
     await downloadButton.click();
     const download = await downloadPromise;
     await download.saveAs(join(__dirname, "data", "downloaded-java-tests.zip"));
-    */
   });
 
   test("Student appears in the grades list", async ({ page }) => {

--- a/src/hooks/laboratories/editLaboratoryReducer.ts
+++ b/src/hooks/laboratories/editLaboratoryReducer.ts
@@ -68,7 +68,6 @@ export function editLaboratoryReducer(
         index: state.laboratory!.blocks.length,
         blockType: "test",
         languageUUID: action.payload.languageUUID,
-        testArchiveUUID: action.payload.testArchiveUUID,
         name: action.payload.name
       };
 

--- a/src/hooks/laboratories/editLaboratoryTypes.ts
+++ b/src/hooks/laboratories/editLaboratoryTypes.ts
@@ -48,7 +48,6 @@ export type EditLaboratoryAction =
       payload: {
         uuid: string;
         languageUUID: string;
-        testArchiveUUID: string;
         name: string;
       };
     }
@@ -57,7 +56,6 @@ export type EditLaboratoryAction =
       payload: {
         uuid: string;
         languageUUID: string;
-        testArchiveUUID: string;
         name: string;
       };
     }

--- a/src/screens/complete-laboratory/StudentsLaboratoryView.tsx
+++ b/src/screens/complete-laboratory/StudentsLaboratoryView.tsx
@@ -82,7 +82,10 @@ export const StudentsLaboratoryView = () => {
           </>
         }
       >
-        <StudentLaboratoryBlocks blocks={laboratory.blocks} />
+        <StudentLaboratoryBlocks
+          laboratoryUUID={laboratoryUUID!}
+          blocks={laboratory.blocks}
+        />
       </Suspense>
     </main>
   );

--- a/src/screens/complete-laboratory/components/StudentLaboratoryBlocks.tsx
+++ b/src/screens/complete-laboratory/components/StudentLaboratoryBlocks.tsx
@@ -8,10 +8,12 @@ import { MarkdownPreviewBlock } from "./markdown-block/MarkdownPreviewBlock";
 import { TestPreviewBlock } from "./test-block/TestPreviewBlock";
 
 interface StudentLaboratoryBlocksProps {
+  laboratoryUUID: string;
   blocks: LaboratoryBlock[];
 }
 
 export const StudentLaboratoryBlocks = ({
+  laboratoryUUID,
   blocks
 }: StudentLaboratoryBlocksProps) => {
   return (
@@ -29,6 +31,7 @@ export const StudentLaboratoryBlocks = ({
           const testBlock: TestBlock = block as TestBlock;
           return (
             <TestPreviewBlock
+              laboratoryUUID={laboratoryUUID}
               block={testBlock}
               blockIndex={index}
               key={`block-${testBlock.uuid}`}

--- a/src/screens/complete-laboratory/components/test-block/TestPreviewBlock.tsx
+++ b/src/screens/complete-laboratory/components/test-block/TestPreviewBlock.tsx
@@ -6,11 +6,13 @@ import { TestPreviewBlockForm } from "./TestPreviewBlockForm";
 import { TestStatus } from "./TestStatus";
 
 interface TestPreviewBlockProps {
+  laboratoryUUID: string;
   block: TestBlock;
   blockIndex: number;
 }
 
 export const TestPreviewBlock = ({
+  laboratoryUUID,
   block,
   blockIndex
 }: TestPreviewBlockProps) => {
@@ -37,6 +39,7 @@ export const TestPreviewBlock = ({
       </TabsList>
       <TabsContent value={`${block.uuid}-form`}>
         <TestPreviewBlockForm
+          laboratoryUUID={laboratoryUUID}
           testBlock={block}
           blockIndex={blockIndex}
           changeToStatusTabCallback={() => setActiveTab(`${block.uuid}-status`)}

--- a/src/screens/edit-laboratory/dialogs/CreateTestBlockForm.tsx
+++ b/src/screens/edit-laboratory/dialogs/CreateTestBlockForm.tsx
@@ -118,13 +118,11 @@ export const CreateTestBlockForm = ({
       createdTestBlockUUID,
       { blockName, blockLanguageUUID, laboratoryUUID }
     ) => {
-      // TODO: Receive the test archive UUID from the server
       const newTestBlok: TestBlock = {
         uuid: createdTestBlockUUID,
         name: blockName,
         languageUUID: blockLanguageUUID,
         index: laboratoryState.laboratory!.blocks.length,
-        testArchiveUUID: "PLACEHOLDER",
         blockType: "test"
       };
 

--- a/src/screens/edit-student-grade/components/grading-sidebar/submissions/GradingSubmissionsSummary.tsx
+++ b/src/screens/edit-student-grade/components/grading-sidebar/submissions/GradingSubmissionsSummary.tsx
@@ -1,5 +1,6 @@
 import { CustomError } from "@/components/CustomError";
 import { EmptyContentText } from "@/components/EmptyContentText";
+import { StudentSubmissionsSkeleton } from "@/screens/edit-student-grade/skeletons/StudentSubmissionsSkeleton";
 import { getProgressOfStudentService } from "@/services/laboratories/ger-progress-of-student.service";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -42,8 +43,7 @@ export const GradingSubmissionsSummary = ({
 
   // Handle loading state
   if (isLoadingSubmissionsSummary) {
-    // TODO: Replace this with a proper loading component
-    return <div>Loading...</div>;
+    return <StudentSubmissionsSkeleton />;
   }
 
   // Handle error state

--- a/src/screens/edit-student-grade/skeletons/StudentSubmissionSummaryCardSkeleton.tsx
+++ b/src/screens/edit-student-grade/skeletons/StudentSubmissionSummaryCardSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const StudentSubmissionSummaryCardSkeleton = () => {
+  return (
+    <div className="flex flex-wrap justify-between gap-2 rounded-md border p-4 shadow-sm">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-6 w-24" />
+        <span className="flex items-center gap-1 capitalize text-black/75">
+          <Skeleton className="h-3 w-3 rounded-full" />
+          <Skeleton className="h-5 w-12" />
+        </span>
+      </div>
+      <div className="flex items-center">
+        <Skeleton className="h-10 w-10" />
+      </div>
+    </div>
+  );
+};

--- a/src/screens/edit-student-grade/skeletons/StudentSubmissionsSkeleton.tsx
+++ b/src/screens/edit-student-grade/skeletons/StudentSubmissionsSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { StudentSubmissionSummaryCardSkeleton } from "./StudentSubmissionSummaryCardSkeleton";
+
+const submissionCardsToRender = Array.from({ length: 3 }, (_, index) => index);
+
+export const StudentSubmissionsSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-7 w-1/3" />
+      <Skeleton className="h-12 w-full" />
+      <ul className="flex flex-col gap-4">
+        {submissionCardsToRender.map((_, index) => (
+          <li key={`student-submission-skeleton-${index}`}>
+            <StudentSubmissionSummaryCardSkeleton />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};

--- a/src/services/laboratories/get-laboratory-by-uuid.service.ts
+++ b/src/services/laboratories/get-laboratory-by-uuid.service.ts
@@ -16,7 +16,6 @@ type markdownBlockBackendResponse = {
 type testBlockBackendResponse = {
   uuid: string;
   language_uuid: string;
-  test_archive_uuid: string;
   submission_uuid: string;
   name: string;
   index: number;
@@ -55,7 +54,6 @@ export async function getLaboratoryByUUIDService(
       (block: testBlockBackendResponse) => ({
         uuid: block.uuid,
         languageUUID: block.language_uuid,
-        testArchiveUUID: block.test_archive_uuid,
         submissionUUID: block.submission_uuid,
         name: block.name,
         index: block.index,

--- a/src/types/entities/laboratory-entities.ts
+++ b/src/types/entities/laboratory-entities.ts
@@ -10,7 +10,6 @@ export type MarkdownBlock = {
 export type TestBlock = {
   uuid: string;
   languageUUID: string;
-  testArchiveUUID: string;
   name: string;
   index: number;
   blockType: BlockType;


### PR DESCRIPTION
## Includes 📋

- Allow students to download the archive of their submissions
- Add missing loading skeleton for the cards of the students' submissions in the grading view
- Add missing test to ensure students can download the archives they've submitted

## Related Issues 🔎

Closes #275 

<!-- ## Notes 📝 -->
<!-- Additional notes or implementation details. -->

<!-- ## Screenshots 📸 -->
<!-- Use the following table template to add mobile screenshots. -->
<!--
|     |     |
| --- | --- |
-->
