### PR TITLE
fix(perf): Improve code splitting

### DIFF
--- a/e2e/rubrics/EditRubric.spec.ts
+++ b/e2e/rubrics/EditRubric.spec.ts
@@ -303,7 +303,7 @@ test.describe.serial("Rubrics edition workflow", () => {
     await page.getByLabel(`Edit ${rubricName}`).click();
 
     // Wait for the input with the rubric name to be visible
-    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Rubric name", {exact: true})).toBeVisible();
 
     // Open the confirmation modal
     const objectiveIndex = 8;

--- a/e2e/rubrics/EditRubric.spec.ts
+++ b/e2e/rubrics/EditRubric.spec.ts
@@ -95,7 +95,7 @@ test.describe.serial("Rubrics edition workflow", () => {
     await page.getByLabel(`Edit ${rubricName}`).click();
 
     // Wait for the input with the rubric name to be visible
-    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Rubric name", {exact: true})).toBeVisible();
 
     // Create objectives with their criteria
     const { objectives } = rubricData;
@@ -161,7 +161,7 @@ test.describe.serial("Rubrics edition workflow", () => {
     await page.getByLabel(`Edit ${rubricName}`).click();
 
     // Wait for the input with the rubric name to be visible
-    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Rubric name", {exact: true})).toBeVisible();
 
     // Update the objective description
     const objectiveIndex = 1;
@@ -201,7 +201,7 @@ test.describe.serial("Rubrics edition workflow", () => {
     await page.getByLabel(`Edit ${rubricName}`).click();
 
     // Wait for the input with the rubric name to be visible
-    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Rubric name", {exact: true})).toBeVisible();
 
     // Update the criteria
     const objectiveIndex = 1;
@@ -260,7 +260,7 @@ test.describe.serial("Rubrics edition workflow", () => {
     await page.getByLabel(`Edit ${rubricName}`).click();
 
     // Wait for the input with the rubric name to be visible
-    await expect(page.getByLabel("Name")).toBeVisible();
+    await expect(page.getByLabel("Rubric name", {exact: true})).toBeVisible();
 
     // Open the confirmation modal
     const objectiveIndex = 8;

--- a/e2e/rubrics/rubric.json
+++ b/e2e/rubrics/rubric.json
@@ -5,6 +5,10 @@
       "description": "Definición de la situación problema",
       "criteria": [
         {
+          "description": "No plantea la situación, necesidad, u oportunidad, que da origen al proyecto que intenta llevar a cabo.",
+          "weight": 0
+        },
+        {
           "description": "Plantea en forma poco clara y no concisa la situación, necesidad, u oportunidad, que da origen al proyecto que intenta llevar a cabo; carece de la formulación de la pregunta de investigación.",
           "weight": 0.05625
         },
@@ -25,6 +29,10 @@
     {
       "description": "Marco tecnológico y conceptual",
       "criteria": [
+        {
+          "description": "No se evidencia indagación de fundamentos conceptuales de las temáticas o áreas asociadas a la situación problema planteada.",
+          "weight": 0
+        },
         {
           "description": "Se demuestra indagación de muy pocos fundamentos conceptuales de las temáticas o áreas asociadas a la situación problema planteada. Las aseveraciones y conceptos presentados carecen de validación por referentes referentes apropiados.",
           "weight": 0.05625
@@ -47,6 +55,10 @@
       "description": "Objetivos",
       "criteria": [
         {
+          "description": "No plantea los objetivos general y específicos.",
+          "weight": 0
+        },
+        {
           "description": "Plantea los objetivos general y específicos; aunque los objetivos específicos no permiten evidenciar la consecución del objetivo general.",
           "weight": 0.1125
         },
@@ -68,6 +80,10 @@
       "description": "Justificación",
       "criteria": [
         {
+          "description": "No sustenta la importancia de realizar el proyecto.",
+          "weight": 0
+        },
+        {
           "description": "La justificación carece de un sustento claro de la importancia de realizar el proyecto.",
           "weight": 0.01875
         },
@@ -88,6 +104,10 @@
     {
       "description": "Metodología",
       "criteria": [
+        {
+          "description": "No se presenta una metodología.",
+          "weight": 0
+        },
         {
           "description": "Aunque se presenta una metodología, la misma no refleja orden en las actividades o tareas que permitan el cumplimiento de los objetivos general y específicos.",
           "weight": 0.075
@@ -111,7 +131,7 @@
       "criteria": [
         {
           "description": "No presenta una lista de requisitos funcionales.",
-          "weight": 0.1125
+          "weight": 0
         },
         {
           "description": "Presenta requisitos funcionales que no describen las características del sistema.",
@@ -132,7 +152,7 @@
       "criteria": [
         {
           "description": "No se evidencian referentes pertinentes en el documento.",
-          "weight": 0.0375
+          "weight": 0
         },
         {
           "description": "Se incluyen menos 8 referentes pertinentes en el documento. 100% de referentes en español.",

--- a/src/components/Skeletons/GenericFormSkeleton.tsx
+++ b/src/components/Skeletons/GenericFormSkeleton.tsx
@@ -1,0 +1,24 @@
+import { InputWithLabelSkeleton } from "@/components/Skeletons/InputWithLabelSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface GenericFormSkeletonProps {
+  inputCount: number;
+}
+
+export const GenericFormSkeleton = ({
+  inputCount
+}: GenericFormSkeletonProps) => {
+  const inputsIndex = [...Array(inputCount)].map((_, index) => index);
+
+  return (
+    <div className="mx-auto my-4 max-w-md space-y-4 border p-4 shadow-sm">
+      {/* Title */}
+      <Skeleton className="mx-auto h-9 w-3/4" />
+      {inputsIndex.map((index) => (
+        <InputWithLabelSkeleton key={`input-group-skeleton-${index}`} />
+      ))}
+      {/* Submit button */}
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+};

--- a/src/components/Skeletons/HighlightableRubricSkeleton.tsx
+++ b/src/components/Skeletons/HighlightableRubricSkeleton.tsx
@@ -3,7 +3,6 @@ import { RubricObjectivesSkeleton } from "@/screens/edit-rubric/skeletons/Rubric
 export const HighlightableRubricSkeleton = () => {
   return (
     <div className="flex max-w-[calc(100vw-2rem)] flex-col gap-4 md:col-span-3">
-      {/* rubric skeleton */}
       <RubricObjectivesSkeleton />
     </div>
   );

--- a/src/components/Skeletons/InputWithLabelSkeleton.tsx
+++ b/src/components/Skeletons/InputWithLabelSkeleton.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from "../ui/skeleton";
+
+export const InputWithLabelSkeleton = () => {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-4 w-16" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,39 +1,96 @@
-// Import components and views
 import { AuthMiddleware } from "@/components/AuthMiddleware";
 import { Footer } from "@/components/Footer/Footer";
 import { Navbar } from "@/components/Navbar/Navbar.tsx";
+import { GenericFormSkeleton } from "@/components/Skeletons/GenericFormSkeleton";
 import { AuthContextProvider } from "@/context/AuthContext";
 import { UserCoursesDialogsProvider } from "@/context/courses/UserCoursesDialogsContext";
 import { EditLaboratoryProvider } from "@/context/laboratories/EditLaboratoryContext";
-import { AdminsView } from "@/screens/admins-list/AdminsView";
-import { StudentsLaboratoryView } from "@/screens/complete-laboratory/StudentsLaboratoryView";
-import { CoursePageLayout } from "@/screens/course-page/CoursePageLayout";
-import { CourseLaboratories } from "@/screens/course-page/laboratories/CourseLaboratories";
-import { CourseParticipants } from "@/screens/course-page/participants/CourseParticipants";
-import { CoursesHome } from "@/screens/courses-list/CoursesHome";
-import { EditLaboratory } from "@/screens/edit-laboratory/EditLaboratory";
-import { EditRubricView } from "@/screens/edit-rubric/EditRubricView";
+import { AdminsViewSkeleton } from "@/screens/admins-list/skeletons/AdminsViewSkeleton";
+import { CompleteLaboratoryViewSkeleton } from "@/screens/complete-laboratory/skeletons/CompleteLaboratoryViewSkeleton";
+import { CourseLaboratoriesOutletSkeleton } from "@/screens/course-page/laboratories/skeletons/CourseLaboratoriesOutletSkeleton";
+import { CourseParticipantsOutletSkeleton } from "@/screens/course-page/participants/skeletons/CourseParticipantsOutletSkeleton";
+import { CoursePageLayoutSkeleton } from "@/screens/course-page/skeletons/CoursePageLayoutSkeleton";
+import { CoursesHomeSkeleton } from "@/screens/courses-list/skeletons/CoursesHomeSkeleton";
+import { EditLaboratoryPageSkeleton } from "@/screens/edit-laboratory/skeletons/EditLaboratoryPageSkeleton";
+import { EditRubricViewSkeleton } from "@/screens/edit-rubric/skeletons/EditRubricViewSkeleton";
+import { EditStudentGradeLayoutSkeleton } from "@/screens/edit-student-grade/skeletons/EditStudentGradeLayoutSkeleton";
 import { Home } from "@/screens/home/Home";
-import { ProfileView } from "@/screens/profile/ProfileView";
-import { RubricsHome } from "@/screens/rubrics-list/RubricsHome";
+import { LaboratoryGradesViewSkeleton } from "@/screens/laboratory-grades/skeletons/LaboratoryGradesViewSkeleton";
+import { LaboratoryProgressDashboardSkeleton } from "@/screens/laboratory-progress/skeletons/LaboratoryProgressDashboardSkeleton";
+import { UpdateProfileSkeleton } from "@/screens/profile/skeletons/UpdateProfileSkeleton";
+import { RubricsHomeSkeleton } from "@/screens/rubrics-list/skeletons/RubricsHomeSkeleton";
 import { FormContainer } from "@/screens/session/FormContainer";
 import { Login } from "@/screens/session/login/Login";
 import { Logout } from "@/screens/session/logout/Logout";
-import { RegisterAdminForm } from "@/screens/session/register-admin/Form";
 import { RegisterStudentForm } from "@/screens/session/register-student/Form";
-import { RegisterTeacherForm } from "@/screens/session/register-teacher/Form";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { Suspense } from "react";
 import ReactDOM from "react-dom/client";
+import { lazily } from "react-lazily";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Toaster } from "sonner";
 
 // Apply global styles
 import "./global.css";
-import { EditStudentGradeView } from "./screens/edit-student-grade/EditStudentGradeView";
-import { LaboratoryGrades } from "./screens/laboratory-grades/LaboratoryGrades";
-import { LaboratoryProgressView } from "./screens/laboratory-progress/LaboratoryProgressView";
-import { MyGradeView } from "./screens/my-grade/MyGradeView";
+
+const { RegisterAdminView } = lazily(
+  () => import("@/screens/session/register-admin/RegisterAdminView")
+);
+
+const { RegisterTeacherView } = lazily(
+  () => import("@/screens/session/register-teacher/RegisterTeacherView")
+);
+
+const { ProfileView } = lazily(() => import("@/screens/profile/ProfileView"));
+
+const { AdminsView } = lazily(() => import("@/screens/admins-list/AdminsView"));
+
+const { CoursesHome } = lazily(
+  () => import("@/screens/courses-list/CoursesHome")
+);
+
+const { CoursePageLayout } = lazily(
+  () => import("@/screens/course-page/CoursePageLayout")
+);
+
+const { CourseLaboratories } = lazily(
+  () => import("@/screens/course-page/laboratories/CourseLaboratories")
+);
+
+const { EditLaboratory } = lazily(
+  () => import("@/screens/edit-laboratory/EditLaboratory")
+);
+
+const { StudentsLaboratoryView } = lazily(
+  () => import("@/screens/complete-laboratory/StudentsLaboratoryView")
+);
+
+const { LaboratoryProgressView } = lazily(
+  () => import("@/screens/laboratory-progress/LaboratoryProgressView")
+);
+
+const { CourseParticipants } = lazily(
+  () => import("@/screens/course-page/participants/CourseParticipants")
+);
+
+const { RubricsHome } = lazily(
+  () => import("@/screens/rubrics-list/RubricsHome")
+);
+
+const { EditRubricView } = lazily(
+  () => import("@/screens/edit-rubric/EditRubricView")
+);
+
+const { LaboratoryGrades } = lazily(
+  () => import("@/screens/laboratory-grades/LaboratoryGrades")
+);
+
+const { EditStudentGradeView } = lazily(
+  () => import("@/screens/edit-student-grade/EditStudentGradeView")
+);
+
+const { MyGradeView } = lazily(() => import("@/screens/my-grade/MyGradeView"));
 
 // Define query client
 const queryClient = new QueryClient({
@@ -78,7 +135,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/register/admins"
             element={
               <AuthMiddleware mustBeLoggedIn roles={["admin"]}>
-                <FormContainer form={<RegisterAdminForm />} />
+                <Suspense fallback={<GenericFormSkeleton inputCount={3} />}>
+                  <RegisterAdminView />
+                </Suspense>
               </AuthMiddleware>
             }
           />
@@ -86,7 +145,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/register/teachers"
             element={
               <AuthMiddleware mustBeLoggedIn roles={["admin"]}>
-                <FormContainer form={<RegisterTeacherForm />} />
+                <Suspense fallback={<GenericFormSkeleton inputCount={3} />}>
+                  <RegisterTeacherView />
+                </Suspense>
               </AuthMiddleware>
             }
           />
@@ -94,7 +155,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/profile"
             element={
               <AuthMiddleware mustBeLoggedIn>
-                <ProfileView />
+                <Suspense fallback={<UpdateProfileSkeleton />}>
+                  <ProfileView />
+                </Suspense>
               </AuthMiddleware>
             }
           />
@@ -102,7 +165,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/admins"
             element={
               <AuthMiddleware mustBeLoggedIn roles={["admin"]}>
-                <AdminsView />
+                <Suspense fallback={<AdminsViewSkeleton />}>
+                  <AdminsView />
+                </Suspense>
               </AuthMiddleware>
             }
           />
@@ -111,7 +176,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             element={
               <UserCoursesDialogsProvider>
                 <AuthMiddleware mustBeLoggedIn roles={["teacher", "student"]}>
-                  <CoursesHome />
+                  <Suspense fallback={<CoursesHomeSkeleton />}>
+                    <CoursesHome />
+                  </Suspense>
                 </AuthMiddleware>
               </UserCoursesDialogsProvider>
             }
@@ -120,7 +187,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/courses/:courseUUID"
             element={
               <AuthMiddleware mustBeLoggedIn roles={["teacher", "student"]}>
-                <CoursePageLayout />
+                <Suspense fallback={<CoursePageLayoutSkeleton />}>
+                  <CoursePageLayout />
+                </Suspense>
               </AuthMiddleware>
             }
           >
@@ -128,7 +197,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher", "student"]}>
-                  <CourseLaboratories />
+                  <Suspense fallback={<CourseLaboratoriesOutletSkeleton />}>
+                    <CourseLaboratories />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -136,9 +207,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/edit"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher"]}>
-                  <EditLaboratoryProvider>
-                    <EditLaboratory />
-                  </EditLaboratoryProvider>
+                  <Suspense fallback={<EditLaboratoryPageSkeleton />}>
+                    <EditLaboratoryProvider>
+                      <EditLaboratory />
+                    </EditLaboratoryProvider>
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -146,7 +219,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/complete"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["student"]}>
-                  <StudentsLaboratoryView />
+                  <Suspense fallback={<CompleteLaboratoryViewSkeleton />}>
+                    <StudentsLaboratoryView />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -154,7 +229,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/progress"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher"]}>
-                  <LaboratoryProgressView />
+                  <Suspense fallback={<LaboratoryProgressDashboardSkeleton />}>
+                    <LaboratoryProgressView />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -162,7 +239,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/grades"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher"]}>
-                  <LaboratoryGrades />
+                  <Suspense fallback={<LaboratoryGradesViewSkeleton />}>
+                    <LaboratoryGrades />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -170,7 +249,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/students/:studentUUID/edit-grade"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher"]}>
-                  <EditStudentGradeView />
+                  <Suspense fallback={<EditStudentGradeLayoutSkeleton />}>
+                    <EditStudentGradeView />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -178,7 +259,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="laboratories/:laboratoryUUID/my-grade"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["student"]}>
-                  <MyGradeView />
+                  <Suspense fallback={<EditStudentGradeLayoutSkeleton />}>
+                    <MyGradeView />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -186,7 +269,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
               path="participants"
               element={
                 <AuthMiddleware mustBeLoggedIn roles={["teacher"]}>
-                  <CourseParticipants />
+                  <Suspense fallback={<CourseParticipantsOutletSkeleton />}>
+                    <CourseParticipants />
+                  </Suspense>
                 </AuthMiddleware>
               }
             />
@@ -195,7 +280,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/rubrics"
             element={
               <AuthMiddleware roles={["teacher"]} mustBeLoggedIn>
-                <RubricsHome />
+                <Suspense fallback={<RubricsHomeSkeleton />}>
+                  <RubricsHome />
+                </Suspense>
               </AuthMiddleware>
             }
           />
@@ -203,7 +290,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="/rubrics/:rubricUUID"
             element={
               <AuthMiddleware roles={["teacher"]} mustBeLoggedIn>
-                <EditRubricView />
+                <Suspense fallback={<EditRubricViewSkeleton />}>
+                  <EditRubricView />
+                </Suspense>
               </AuthMiddleware>
             }
           />

--- a/src/screens/admins-list/AdminsView.tsx
+++ b/src/screens/admins-list/AdminsView.tsx
@@ -47,8 +47,8 @@ export const AdminsView = () => {
 
   return (
     <main className="mx-auto max-w-7xl p-4">
-      <div className="mb-4 flex flex-row flex-wrap items-center justify-between gap-x-4">
-        <h1 className="my-4 text-3xl font-bold">Administrators list</h1>
+      <div className="mb-4 flex flex-row flex-wrap items-center justify-between gap-4">
+        <h1 className="text-3xl font-bold">Administrators list</h1>
         <Link
           className={buttonVariants({ variant: "default" })}
           to="/register/admins"

--- a/src/screens/admins-list/skeletons/AdminsViewSkeleton.tsx
+++ b/src/screens/admins-list/skeletons/AdminsViewSkeleton.tsx
@@ -1,0 +1,18 @@
+import { GenericTableSkeleton } from "@/components/Skeletons/GenericTableSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const AdminsViewSkeleton = () => {
+  return (
+    <div className="mx-auto max-w-7xl p-4">
+      <div className="mb-4 flex flex-row flex-wrap items-center justify-between gap-4">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-10 w-40" />
+      </div>
+      <GenericTableSkeleton
+        columns={3}
+        rows={8}
+        headers={["Full name", "Creation date", "Created by"]}
+      />
+    </div>
+  );
+};

--- a/src/screens/complete-laboratory/StudentsLaboratoryView.tsx
+++ b/src/screens/complete-laboratory/StudentsLaboratoryView.tsx
@@ -1,15 +1,11 @@
 import { CustomError } from "@/components/CustomError";
-import { LaboratoryBlockSkeleton } from "@/components/Skeletons/LaboratoryBlockSkeleton";
 import { getLaboratoryByUUIDService } from "@/services/laboratories/get-laboratory-by-uuid.service";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { lazily } from "react-lazily";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
-const { StudentLaboratoryBlocks } = lazily(
-  () => import("./components/StudentLaboratoryBlocks")
-);
+import { StudentLaboratoryBlocks } from "./components/StudentLaboratoryBlocks";
+import { CompleteLaboratoryViewSkeleton } from "./skeletons/CompleteLaboratoryViewSkeleton";
 
 export const StudentsLaboratoryView = () => {
   // Url params
@@ -30,15 +26,7 @@ export const StudentsLaboratoryView = () => {
   });
 
   // Handle loading state
-  if (isLoading) {
-    return (
-      <div className="col-span-3">
-        {Array.from({ length: 3 }).map((_, index) => {
-          return <LaboratoryBlockSkeleton key={`laboratory-block-${index}`} />;
-        })}
-      </div>
-    );
-  }
+  if (isLoading) return <CompleteLaboratoryViewSkeleton />;
 
   // Handle error state
   if (isLaboratoryError) {
@@ -69,24 +57,10 @@ export const StudentsLaboratoryView = () => {
 
   return (
     <main className="col-span-3">
-      <Suspense
-        fallback={
-          <>
-            {laboratory.blocks.map((block) => {
-              return (
-                <LaboratoryBlockSkeleton
-                  key={`laboratory-block-${block.uuid}`}
-                />
-              );
-            })}
-          </>
-        }
-      >
-        <StudentLaboratoryBlocks
-          laboratoryUUID={laboratoryUUID!}
-          blocks={laboratory.blocks}
-        />
-      </Suspense>
+      <StudentLaboratoryBlocks
+        laboratoryUUID={laboratoryUUID!}
+        blocks={laboratory.blocks}
+      />
     </main>
   );
 };

--- a/src/screens/complete-laboratory/skeletons/CompleteLaboratoryViewSkeleton.tsx
+++ b/src/screens/complete-laboratory/skeletons/CompleteLaboratoryViewSkeleton.tsx
@@ -1,0 +1,15 @@
+import { LaboratoryBlockSkeleton } from "@/components/Skeletons/LaboratoryBlockSkeleton";
+
+export const CompleteLaboratoryViewSkeleton = () => {
+  const blocksIndexes = Array.from({ length: 3 });
+
+  return (
+    <div className="col-span-3">
+      {blocksIndexes.map((_, index) => {
+        return (
+          <LaboratoryBlockSkeleton key={`laboratory-block-skeleton-${index}`} />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/screens/course-page/CoursePageLayout.tsx
+++ b/src/screens/course-page/CoursePageLayout.tsx
@@ -16,7 +16,7 @@ export const CoursePageLayout = () => {
 
   // Global user state
   const { user } = useContext(AuthContext);
-  const role = user?.role || "student";
+  const role = user?.role ?? "student";
   // Fetching state
   const {
     data: course,

--- a/src/screens/course-page/laboratories/CourseLaboratories.tsx
+++ b/src/screens/course-page/laboratories/CourseLaboratories.tsx
@@ -34,7 +34,7 @@ export const CourseLaboratories = () => {
 
   return (
     <main className="col-span-3">
-      <div className="flex flex-col items-start justify-between md:flex-row md:items-center">
+      <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
         <h1 className="my-4 text-3xl font-bold">Course laboratories</h1>
         {user!.role == "teacher" && <CreateLaboratoryDialog />}
       </div>

--- a/src/screens/course-page/laboratories/components/CourseLaboratoriesTable.tsx
+++ b/src/screens/course-page/laboratories/components/CourseLaboratoriesTable.tsx
@@ -95,7 +95,7 @@ export const CourseLaboratoriesTable = ({
       <GenericTableSkeleton
         headers={["Name", "Opening date", "Due date", "Actions"]}
         columns={4}
-        rows={8}
+        rows={4}
       />
     );
   }

--- a/src/screens/course-page/laboratories/skeletons/CourseLaboratoriesOutletSkeleton.tsx
+++ b/src/screens/course-page/laboratories/skeletons/CourseLaboratoriesOutletSkeleton.tsx
@@ -1,0 +1,11 @@
+import { CoursePageTabularOutletSkeleton } from "../../skeletons/CoursePageTabularOutletSkeleton";
+
+export const CourseLaboratoriesOutletSkeleton = () => {
+  return (
+    <CoursePageTabularOutletSkeleton
+      tableColumns={4}
+      tableRows={4}
+      tableHeaders={["Name", "Opening date", "Due date", "Actions"]}
+    />
+  );
+};

--- a/src/screens/course-page/participants/skeletons/CourseParticipantsOutletSkeleton.tsx
+++ b/src/screens/course-page/participants/skeletons/CourseParticipantsOutletSkeleton.tsx
@@ -1,0 +1,11 @@
+import { CoursePageTabularOutletSkeleton } from "../../skeletons/CoursePageTabularOutletSkeleton";
+
+export const CourseParticipantsOutletSkeleton = () => {
+  return (
+    <CoursePageTabularOutletSkeleton
+      tableColumns={3}
+      tableRows={4}
+      tableHeaders={["Full name", "Institutional Id", "Actions"]}
+    />
+  );
+};

--- a/src/screens/course-page/skeletons/CoursePageLayoutSkeleton.tsx
+++ b/src/screens/course-page/skeletons/CoursePageLayoutSkeleton.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from "react-router-dom";
+
+import { CourseNavigationSkeleton } from "../CourseNavigationSkeleton";
+
+export const CoursePageLayoutSkeleton = () => {
+  return (
+    <div className="mx-auto grid min-h-[calc(100vh-5rem)] max-w-7xl auto-rows-min gap-4 p-4 md:auto-rows-auto md:grid-cols-4">
+      <aside className="space-y-8 pb-2 pr-2 md:border-r md:pb-0">
+        <CourseNavigationSkeleton />
+      </aside>
+      <Outlet />
+    </div>
+  );
+};

--- a/src/screens/course-page/skeletons/CoursePageTabularOutletSkeleton.tsx
+++ b/src/screens/course-page/skeletons/CoursePageTabularOutletSkeleton.tsx
@@ -1,0 +1,30 @@
+import { GenericTableSkeleton } from "@/components/Skeletons/GenericTableSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface CoursePageTabularOutletSkeletonProps {
+  tableColumns?: number;
+  tableRows?: number;
+  tableHeaders?: string[];
+}
+
+export const CoursePageTabularOutletSkeleton = ({
+  tableColumns = 3,
+  tableRows = 4,
+  tableHeaders = []
+}: CoursePageTabularOutletSkeletonProps) => {
+  return (
+    <div className="md:col-span-3">
+      <div className="my-4 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-10 w-44" />
+      </div>
+      <div className="mt-12">
+        <GenericTableSkeleton
+          columns={tableColumns}
+          rows={tableRows}
+          headers={tableHeaders}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/screens/courses-list/skeletons/CoursesHomeSkeleton.tsx
+++ b/src/screens/courses-list/skeletons/CoursesHomeSkeleton.tsx
@@ -1,0 +1,21 @@
+import { GridContainer } from "@/components/GridContainer";
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { CourseCardSkeleton } from "../components/CourseCardSkeleton";
+
+export const CoursesHomeSkeleton = () => {
+  const visibleCoursesIndexes = Array.from({ length: 6 }).map((_, i) => i);
+
+  return (
+    <div className="mx-auto flex max-w-7xl flex-col p-4">
+      <div className="my-4 space-y-4">
+        <Skeleton className="h-6 w-24" />
+        <GridContainer>
+          {visibleCoursesIndexes.map((i) => (
+            <CourseCardSkeleton key={`course-skeleton-${i}`} />
+          ))}
+        </GridContainer>
+      </div>
+    </div>
+  );
+};

--- a/src/screens/edit-laboratory/EditLaboratory.tsx
+++ b/src/screens/edit-laboratory/EditLaboratory.tsx
@@ -11,21 +11,13 @@ import {
 } from "@/types/entities/laboratory-entities";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { TextCursor } from "lucide-react";
-import { Suspense, useContext } from "react";
-import { lazily } from "react-lazily";
+import { useContext } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
-import { LaboratoryBlockSkeleton } from "../../components/Skeletons/LaboratoryBlockSkeleton";
+import { LaboratoryDetails } from "./components/LaboratoryDetails";
+import { TeacherLaboratoryBlocks } from "./components/TeacherLaboratoryBlocks";
 import { CreateTestBlockDialog } from "./dialogs/CreateTestBlockDialog";
-import { LaboratoryDetailsSkeleton } from "./skeletons/LaboratoryDetailsSkeleton";
-
-const { LaboratoryDetails } = lazily(
-  () => import("./components/LaboratoryDetails")
-);
-const { TeacherLaboratoryBlocks } = lazily(
-  () => import("./components/TeacherLaboratoryBlocks")
-);
 
 export const EditLaboratory = () => {
   // Global laboratory state
@@ -120,29 +112,13 @@ export const EditLaboratory = () => {
 
   return (
     <main className="col-span-3">
-      {/* Header to update base laboratory details */}
-      <Suspense fallback={<LaboratoryDetailsSkeleton />}>
-        <LaboratoryDetails
-          laboratoryDetails={{
-            ...laboratory
-          }}
-        />
-      </Suspense>
-
-      {/* Horizontal line to separate the content */}
+      <LaboratoryDetails
+        laboratoryDetails={{
+          ...laboratory
+        }}
+      />
       <Separator className="my-8" />
-
-      {/* Laboratory blocks */}
-      <Suspense
-        fallback={
-          <>
-            <LaboratoryBlockSkeleton />
-            <LaboratoryBlockSkeleton />
-          </>
-        }
-      >
-        <TeacherLaboratoryBlocks blocks={laboratory.blocks} />
-      </Suspense>
+      <TeacherLaboratoryBlocks blocks={laboratory.blocks} />
 
       {/* Buttons to add blocks */}
       <Button onClick={handleAddTextBlock}>

--- a/src/screens/edit-rubric/EditRubricView.tsx
+++ b/src/screens/edit-rubric/EditRubricView.tsx
@@ -1,20 +1,15 @@
 import { CustomError } from "@/components/CustomError";
 import { getRubricByUUIDService } from "@/services/rubrics/get-rubric-by-uuid.service";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { lazily } from "react-lazily";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { ObjectiveRow } from "./components/ObjectiveRow";
+import { RubricName } from "./components/RubricName";
 import { DeleteCriteriaDialog } from "./dialogs/DeleteCriteriaDialog";
 import { DeleteObjectiveDialog } from "./dialogs/DeleteObjectiveDialog";
 import { AddObjectiveDialog } from "./dialogs/add-objective/AddObjectiveDialog";
-import { RubricNameSkeleton } from "./skeletons/RubricNameSkeleton";
-import { RubricSkeleton } from "./skeletons/RubricSkeleton";
-
-const { RubricName } = lazily(() => import("./components/RubricName"));
-
-const { ObjectiveRow } = lazily(() => import("./components/ObjectiveRow"));
+import { EditRubricViewSkeleton } from "./skeletons/EditRubricViewSkeleton";
 
 export const EditRubricView = () => {
   // Get rubric UUID from URL
@@ -46,7 +41,7 @@ export const EditRubricView = () => {
   }
 
   if (isLoadingRubric) {
-    return <RubricSkeleton />;
+    return <EditRubricViewSkeleton />;
   }
 
   if (!rubric) {
@@ -63,18 +58,14 @@ export const EditRubricView = () => {
 
   return (
     <main className="mx-auto max-w-7xl space-y-4 p-4">
-      <Suspense fallback={<RubricNameSkeleton />}>
-        <RubricName rubric={rubric} />
-      </Suspense>
+      <RubricName rubric={rubric} />
       {rubric.objectives?.map((objective, oi) => (
-        <Suspense key={`${objective.uuid}-skeleton`}>
-          <ObjectiveRow
-            key={`${objective.uuid}-objective-row`}
-            rubricUUID={id}
-            objective={objective}
-            objectiveIndex={oi}
-          />
-        </Suspense>
+        <ObjectiveRow
+          key={`${objective.uuid}-objective-row`}
+          rubricUUID={id}
+          objective={objective}
+          objectiveIndex={oi}
+        />
       ))}
       <AddObjectiveDialog rubricUUID={id} />
       <DeleteCriteriaDialog rubricUUID={id} />

--- a/src/screens/edit-rubric/components/CriteriaCard/CriteriaCard.tsx
+++ b/src/screens/edit-rubric/components/CriteriaCard/CriteriaCard.tsx
@@ -128,7 +128,7 @@ export const CriteriaCard = memo(
     };
 
     return (
-      <article className="relative">
+      <article className="relative aspect-square w-full max-w-[18rem] flex-shrink-0 border p-4 shadow-md transition-colors hover:shadow-lg sm:w-72">
         <CriteriaCardDropdown
           criteriaIndex={criteriaIndex}
           criteriaUUID={criteria.uuid}
@@ -138,7 +138,7 @@ export const CriteriaCard = memo(
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex aspect-square w-full max-w-[18rem] flex-shrink-0 flex-col gap-2 border p-4 shadow-md transition-colors hover:shadow-lg sm:w-72"
+            className="flex h-full flex-col gap-2"
           >
             <h2 className="text-xl font-bold">Criteria {criteriaIndex + 1}</h2>
             <FormField

--- a/src/screens/edit-rubric/components/ObjectiveCard/ObjectiveCard.tsx
+++ b/src/screens/edit-rubric/components/ObjectiveCard/ObjectiveCard.tsx
@@ -95,11 +95,11 @@ export const ObjectiveCard = memo(
     const onSubmit = async (data: z.infer<typeof ObjectiveSchema>) => {
       const { description } = data;
       const { uuid } = initialObjective;
-      await updateObjectiveMutation({ objectiveUUID: uuid, description });
+      updateObjectiveMutation({ objectiveUUID: uuid, description });
     };
 
     return (
-      <article className="relative">
+      <article className="relative aspect-square w-full max-w-[18rem] flex-shrink-0 border p-4 shadow-md transition-colors hover:shadow-lg sm:w-72">
         <ObjectiveCardDropdown
           objectiveIndex={objectiveIndex}
           objectiveUUID={initialObjective.uuid}
@@ -108,7 +108,7 @@ export const ObjectiveCard = memo(
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex aspect-square w-full max-w-[18rem] flex-shrink-0 flex-col gap-2 border p-4 shadow-md transition-colors hover:shadow-lg sm:w-72"
+            className="flex h-full flex-col gap-2"
           >
             <h2 className="text-xl font-bold">
               Objective {objectiveIndex + 1}

--- a/src/screens/edit-rubric/skeletons/EditRubricViewSkeleton.tsx
+++ b/src/screens/edit-rubric/skeletons/EditRubricViewSkeleton.tsx
@@ -1,0 +1,11 @@
+import { RubricNameSkeleton } from "./RubricNameSkeleton";
+import { RubricObjectivesSkeleton } from "./RubricObjectivesSkeleton";
+
+export const EditRubricViewSkeleton = () => {
+  return (
+    <div className="mx-auto max-w-7xl space-y-4 p-4">
+      <RubricNameSkeleton />
+      <RubricObjectivesSkeleton />
+    </div>
+  );
+};

--- a/src/screens/edit-student-grade/EditStudentGradeView.tsx
+++ b/src/screens/edit-student-grade/EditStudentGradeView.tsx
@@ -3,17 +3,12 @@ import { getGradeOfStudentInLaboratoryService } from "@/services/grades/get-grad
 import { getLaboratoryInformationByUUIDService } from "@/services/laboratories/get-laboratory-information-by-uuid.service";
 import { getRubricByUUIDService } from "@/services/rubrics/get-rubric-by-uuid.service";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { lazily } from "react-lazily";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { EditStudentGradeLayout } from "./components/EditStudentGradeLayout";
 import { NoRubricChosen } from "./components/NoRubricChosen";
 import { EditStudentGradeLayoutSkeleton } from "./skeletons/EditStudentGradeLayoutSkeleton";
-
-const { EditStudentGradeLayout } = lazily(
-  () => import("./components/EditStudentGradeLayout")
-);
 
 const handleViewError = (
   error: Error,
@@ -150,17 +145,15 @@ export const EditStudentGradeView = () => {
     );
 
   return (
-    <Suspense fallback={<EditStudentGradeLayoutSkeleton />}>
-      <EditStudentGradeLayout
-        ids={{
-          courseUUID: courseUUID!,
-          laboratoryUUID: laboratoryUUID!,
-          studentUUID: studentUUID!
-        }}
-        rubric={rubric}
-        studentGrade={studentGrade}
-        selectedCriteriaByObjectiveMap={selectedCriteriaByObjectiveMap}
-      />
-    </Suspense>
+    <EditStudentGradeLayout
+      ids={{
+        courseUUID: courseUUID!,
+        laboratoryUUID: laboratoryUUID!,
+        studentUUID: studentUUID!
+      }}
+      rubric={rubric}
+      studentGrade={studentGrade}
+      selectedCriteriaByObjectiveMap={selectedCriteriaByObjectiveMap}
+    />
   );
 };

--- a/src/screens/edit-student-grade/skeletons/EditStudentGradeLayoutSkeleton.tsx
+++ b/src/screens/edit-student-grade/skeletons/EditStudentGradeLayoutSkeleton.tsx
@@ -10,12 +10,10 @@ export const EditStudentGradeLayoutSkeleton = () => {
         {/* Go back button */}
         <Skeleton className="h-10 w-28" />
       </div>
-      <div className="grid w-full gap-8 md:grid-cols-5">
-        <HighlightableRubricSkeleton />
-        <div className="-order-1 md:order-1 md:col-span-2">
-          <GradingSidebarSkeleton />
-        </div>
+      <div className="max-w-[18rem]">
+        <GradingSidebarSkeleton />
       </div>
+      <HighlightableRubricSkeleton />
     </div>
   );
 };

--- a/src/screens/laboratory-grades/LaboratoryGrades.tsx
+++ b/src/screens/laboratory-grades/LaboratoryGrades.tsx
@@ -1,19 +1,15 @@
 import { CustomError } from "@/components/CustomError";
-import { GenericTableSkeleton } from "@/components/Skeletons/GenericTableSkeleton";
 import { getEnrolledStudentsService } from "@/services/courses/get-enrolled-students.service";
 import {
   getSummarizedGradesInLaboratoryService,
   summarizedGradeDTO
 } from "@/services/grades/get-summarized-grades-in-laboratory.service";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { lazily } from "react-lazily";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
-const { LaboratoryGradesTable } = lazily(
-  () => import("./components/LaboratoryGradesTable")
-);
+import { LaboratoryGradesTable } from "./components/LaboratoryGradesTable";
+import { LaboratoryGradesViewSkeleton } from "./skeletons/LaboratoryGradesViewSkeleton";
 
 export const LaboratoryGrades = () => {
   // Get the course UUID and laboratory UUID from the URL
@@ -46,7 +42,7 @@ export const LaboratoryGrades = () => {
 
   // Join the two datasets
   // TODO: Check why the backend is returning null instead of an empty array
-  const summarizedGradesFallback = summarizedGrades?.grades || [];
+  const summarizedGradesFallback = summarizedGrades?.grades ?? [];
   const studentsGradesMap = summarizedGradesFallback.reduce(
     (acc, curr) => {
       acc[curr.student_uuid] = curr;
@@ -68,17 +64,9 @@ export const LaboratoryGrades = () => {
     });
   }
 
-  const loadingComponent = (
-    <GenericTableSkeleton
-      headers={["Student name", "Grade", "Actions"]}
-      columns={3}
-      rows={4}
-    />
-  );
-
   // Handle loading state
   if (isLoadingStudents || isLoadingSummarizedGrades) {
-    return <div className="col-span-3">{loadingComponent}</div>;
+    return <LaboratoryGradesViewSkeleton />;
   }
 
   // Handle error state
@@ -103,13 +91,11 @@ export const LaboratoryGrades = () => {
 
   return (
     <main className="col-span-3">
-      <Suspense fallback={loadingComponent}>
-        <LaboratoryGradesTable
-          grades={Object.values(studentsGradesMap!)}
-          courseUUID={courseUUID!}
-          laboratoryUUID={laboratoryUUID!}
-        />
-      </Suspense>
+      <LaboratoryGradesTable
+        grades={Object.values(studentsGradesMap)}
+        courseUUID={courseUUID!}
+        laboratoryUUID={laboratoryUUID!}
+      />
     </main>
   );
 };

--- a/src/screens/laboratory-grades/skeletons/LaboratoryGradesViewSkeleton.tsx
+++ b/src/screens/laboratory-grades/skeletons/LaboratoryGradesViewSkeleton.tsx
@@ -1,0 +1,13 @@
+import { GenericTableSkeleton } from "@/components/Skeletons/GenericTableSkeleton";
+
+export const LaboratoryGradesViewSkeleton = () => {
+  return (
+    <div className="col-span-3">
+      <GenericTableSkeleton
+        headers={["Student name", "Grade", "Actions"]}
+        columns={3}
+        rows={4}
+      />
+    </div>
+  );
+};

--- a/src/screens/laboratory-progress/LaboratoryProgressView.tsx
+++ b/src/screens/laboratory-progress/LaboratoryProgressView.tsx
@@ -3,16 +3,11 @@ import { getEnrolledStudentsService } from "@/services/courses/get-enrolled-stud
 import { getStudentsProgressInLaboratory } from "@/services/laboratories/get-students-progress.service";
 import { StudentProgress } from "@/types/entities/laboratory-entities";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { lazily } from "react-lazily";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { LaboratoryProgressDashboard } from "./components/LaboratoryProgressDashboard";
 import { LaboratoryProgressDashboardSkeleton } from "./skeletons/LaboratoryProgressDashboardSkeleton";
-
-const { LaboratoryProgressDashboard } = lazily(
-  () => import("./components/LaboratoryProgressDashboard")
-);
 
 const defaultSubmissionProgress = {
   pending_submissions: 0,
@@ -113,12 +108,10 @@ export const LaboratoryProgressView = () => {
 
   return (
     <main className="col-span-3">
-      <Suspense fallback={<LaboratoryProgressDashboardSkeleton />}>
-        <LaboratoryProgressDashboard
-          totalTestBlocks={progressData!.total_test_blocks}
-          studentsProgress={Object.values(studentsProgressMap!)}
-        />
-      </Suspense>
+      <LaboratoryProgressDashboard
+        totalTestBlocks={progressData.total_test_blocks}
+        studentsProgress={Object.values(studentsProgressMap)}
+      />
     </main>
   );
 };

--- a/src/screens/laboratory-progress/skeletons/StackedStudentsProgressSkeleton.tsx
+++ b/src/screens/laboratory-progress/skeletons/StackedStudentsProgressSkeleton.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const StackedStudentsProgressSkeleton = () => {
-  return <Skeleton className="aspect-[16/6] w-full" />;
+  return <Skeleton className="h-[450px] w-full" />;
 };

--- a/src/screens/my-grade/MyGradeView.tsx
+++ b/src/screens/my-grade/MyGradeView.tsx
@@ -4,15 +4,13 @@ import { getGradeOfStudentInLaboratoryService } from "@/services/grades/get-grad
 import { getLaboratoryInformationByUUIDService } from "@/services/laboratories/get-laboratory-information-by-uuid.service";
 import { getRubricByUUIDService } from "@/services/rubrics/get-rubric-by-uuid.service";
 import { useQuery } from "@tanstack/react-query";
-import { Suspense, useContext } from "react";
-import { lazily } from "react-lazily";
+import { useContext } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { MyGradeLayout } from "./components/MyGradeLayout";
 import { NoRubricChosen } from "./components/NoRubricChosen";
 import { MyGradeLayoutSkeleton } from "./skeletons/MyGradeLayoutSkeleton";
-
-const { MyGradeLayout } = lazily(() => import("./components/MyGradeLayout"));
 
 const handleViewError = (
   error: Error,
@@ -72,7 +70,7 @@ export const MyGradeView = () => {
       getGradeOfStudentInLaboratoryService({
         laboratoryUUID: laboratoryUUID!,
         rubricUUID: laboratoryRubricUUID!,
-        studentUUID: studentUUID!
+        studentUUID: studentUUID
       }),
     // Fetch the grade after the laboratory information is fetched and only if the laboratory has a rubric
     enabled: !!laboratoryRubricUUID
@@ -147,17 +145,15 @@ export const MyGradeView = () => {
     );
 
   return (
-    <Suspense fallback={<MyGradeLayoutSkeleton />}>
-      <MyGradeLayout
-        ids={{
-          courseUUID: courseUUID!,
-          laboratoryUUID: laboratoryUUID!,
-          studentUUID
-        }}
-        rubric={rubric}
-        selectedCriteriaByObjectiveMap={selectedCriteriaByObjectiveMap}
-        studentGrade={studentGrade}
-      />
-    </Suspense>
+    <MyGradeLayout
+      ids={{
+        courseUUID: courseUUID!,
+        laboratoryUUID: laboratoryUUID!,
+        studentUUID
+      }}
+      rubric={rubric}
+      selectedCriteriaByObjectiveMap={selectedCriteriaByObjectiveMap}
+      studentGrade={studentGrade}
+    />
   );
 };

--- a/src/screens/my-grade/skeletons/MyGradeLayoutSkeleton.tsx
+++ b/src/screens/my-grade/skeletons/MyGradeLayoutSkeleton.tsx
@@ -10,12 +10,10 @@ export const MyGradeLayoutSkeleton = () => {
         {/* Go back button */}
         <Skeleton className="h-10 w-28" />
       </div>
-      <div className="grid w-full gap-8 md:grid-cols-5">
-        <HighlightableRubricSkeleton />
-        <div className="-order-1 md:order-1 md:col-span-2">
-          <MyGradeFormSkeleton />
-        </div>
+      <div className="max-w-[18rem]">
+        <MyGradeFormSkeleton />
       </div>
+      <HighlightableRubricSkeleton />
     </div>
   );
 };

--- a/src/screens/profile/skeletons/UpdateProfileSkeleton.tsx
+++ b/src/screens/profile/skeletons/UpdateProfileSkeleton.tsx
@@ -1,3 +1,4 @@
+import { InputWithLabelSkeleton } from "@/components/Skeletons/InputWithLabelSkeleton";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export const UpdateProfileSkeleton = () => {
@@ -10,15 +11,7 @@ export const UpdateProfileSkeleton = () => {
       {/* Form to update the information */}
       <div className="w-full space-y-4">
         {inputs.map((_, i) => (
-          <div
-            className="flex flex-col gap-2"
-            key={`update-profile-input-skeleton-${i}`}
-          >
-            {/* Label */}
-            <Skeleton className="h-5 w-1/3" />
-            {/* Input */}
-            <Skeleton className="h-10 w-full" />
-          </div>
+          <InputWithLabelSkeleton key={`update-profile-input-skeleton-${i}`} />
         ))}
       </div>
       {/* Submit button */}

--- a/src/screens/rubrics-list/skeletons/RubricsHomeSkeleton.tsx
+++ b/src/screens/rubrics-list/skeletons/RubricsHomeSkeleton.tsx
@@ -1,0 +1,20 @@
+import { GenericTableSkeleton } from "@/components/Skeletons/GenericTableSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const RubricsHomeSkeleton = () => {
+  return (
+    <div className="mx-auto max-w-7xl px-4">
+      <div className="my-4 flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+        <Skeleton className="h-9 w-64" />
+        <Skeleton className="h-10 w-44" />
+      </div>
+      <div className="mt-8">
+        <GenericTableSkeleton
+          columns={2}
+          rows={4}
+          headers={["Name", "Options"]}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/screens/session/register-admin/RegisterAdminView.tsx
+++ b/src/screens/session/register-admin/RegisterAdminView.tsx
@@ -1,0 +1,6 @@
+import { FormContainer } from "../FormContainer";
+import { RegisterAdminForm } from "./Form";
+
+export const RegisterAdminView = () => {
+  return <FormContainer form={<RegisterAdminForm />} />;
+};

--- a/src/screens/session/register-teacher/RegisterTeacherView.tsx
+++ b/src/screens/session/register-teacher/RegisterTeacherView.tsx
@@ -1,0 +1,6 @@
+import { FormContainer } from "../FormContainer";
+import { RegisterTeacherForm } from "./Form";
+
+export const RegisterTeacherView = () => {
+  return <FormContainer form={<RegisterTeacherForm />} />;
+};


### PR DESCRIPTION
## Includes 📋

- Lazily import views to the main page instead of lazily import components to each view.

## Related Issues 🔎

Fixes #281 

## Notes 📝 

- Bundle size (No gzipped) was reduced from `726.52 Kb` to `399.45 Kb`

<!-- ## Screenshots 📸 -->
<!-- Use the following table template to add mobile screenshots. -->
<!--
|     |     |
| --- | --- |
-->
